### PR TITLE
Fix tinyurl shortener usage for pyshortener 0.6.0

### DIFF
--- a/failgraph.py
+++ b/failgraph.py
@@ -118,7 +118,7 @@ def main():
     args = parse_args()
     url = get_graphite_url(args.tests, args.smoothing, args.duration)
     webbrowser.open(url)
-    shortener = Shortener('TinyurlShortener')
+    shortener = Shortener('Tinyurl')
     print "URL for sharing: %s" % shortener.short(url)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pyshorteners>=0.6.0
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyshorteners
+pyshorteners>=0.6.0


### PR DESCRIPTION
pyshortener 0.6.0 made a backward incompatible change
to how shorteners are created, this fixes it and sets
the minimum required version of pyshortener in the
requirements.
